### PR TITLE
Add Codex summary README

### DIFF
--- a/README_Codex.md
+++ b/README_Codex.md
@@ -1,0 +1,49 @@
+# Codex Summary of Health Companion
+
+**Author:** ChatGPT
+**Timestamp:** Thu Aug 21 17:51:11 UTC 2025
+
+## Repository Overview
+
+This project implements an intelligent, multi-modal health management system using the Agno framework. It combines multiple specialist agents orchestrated by a router to log health episodes, recall historical information, and provide evidence-based coaching. The system focuses on migraine and chronic pain management while remaining extensible to other conditions.
+
+## Key Components
+
+- **Health Logger v3.1:** Extracts structured data from text, voice, and image inputs with deterministic processing and JSON storage.
+- **Recall Agent:** Answers historical health queries through time-aware search and correlation analysis.
+- **Coach Agent:** Delivers safe, empathetic guidance grounded in a migraine knowledge base with guardrails and fallback strategies.
+- **Router Agent:** Routes user requests to specialist agents using multi-intent classification and confidence thresholds.
+- **Unified Multi-Modal Interface:** Gradio UI accepts combined text, voice, and file inputs for coherent logging and analysis.
+
+## Documentation Highlights (`docs/Linda`)
+
+Implementation reports under `docs/Linda` provide detailed technical breakdowns:
+
+- `architecture_refactor_report.md` – Transformation from monolithic structure to layered architecture with shared primitives and abstract storage.
+- `healthlogger_agent_implementation_report.md` – Pure Agno workflow resolving episode fragmentation and introducing deterministic processing.
+- `recall_agent_implementation_report.md` – Smart toolkit design enabling time-range parsing, episode filtering, and correlation analysis.
+- `coach_agent_implementation_report.md` – Knowledge-grounded coaching agent using ChromaDB and safety guardrails.
+- `router_agent_implementation_report.md` – Stateful orchestrator supporting multi-intent routing and confidence-based fallbacks.
+- `multimodal_health_logger_implementation_report.md` – Extension of Health Logger for image processing with secure file handling.
+- `unified_multimodal_implementation_report.md` – Unified UI flow combining text, voice, and file inputs in a single submission.
+
+These documents chronicle design decisions, technical steps, and testing outcomes for each major feature.
+
+## Getting Started
+
+1. Install dependencies from `requirements.txt` and configure OpenAI API keys.
+2. Run the Gradio application:
+   ```bash
+   python app.py
+   ```
+3. Interact with the "Health Companion (Auto-Router)" agent for comprehensive health management.
+
+## Testing
+
+Execute the test suite with:
+```bash
+pytest
+```
+
+---
+This README_Codex provides a consolidated view of the repository and references deeper implementation reports in `docs/Linda` for further exploration.


### PR DESCRIPTION
## Summary
- Add README_Codex summarizing repository architecture and docs/Linda implementation reports with author and timestamp

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'dotenv', 'sqlalchemy', 'linda_core')*

------
https://chatgpt.com/codex/tasks/task_e_68a75c33f6e0832db1d8f6f786dfdbfa